### PR TITLE
fix: handle source property that's a string literal

### DIFF
--- a/tests/specs/Basic.txt
+++ b/tests/specs/Basic.txt
@@ -83,3 +83,51 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
+
+== should format cell with string value ==
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "typescript"
+    }
+   },
+   "outputs": [],
+   "source": "code block 1\ntesting"
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}
+
+[expect]
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "typescript"
+    }
+   },
+   "outputs": [],
+   "source": "code block 1\ntesting_typescript"
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
It was corrupting the file when the source property was a string literal.